### PR TITLE
fix: dark theme support

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,8 +72,8 @@ const Home = () => {
               rel="noreferrer"
             >
               <Button variant={'outline'} className="gap-1">
-                <div className="h-5 w-5 text-gray-800">
-                  <GitHubIcon />
+                <div className="h-5 w-5 text-gray-800 dark:text-white">
+                  <GitHubIcon fill="currentColor" />
                 </div>
                 Star on Github
               </Button>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -16,25 +16,25 @@ function CSPostHogProvider({ children }: { children: React.ReactNode }) {
 }
 
 function ThemeWatcher() {
-  let { resolvedTheme, setTheme } = useTheme()
+  // let { resolvedTheme, setTheme } = useTheme()
 
-  useEffect(() => {
-    let media = window.matchMedia('(prefers-color-scheme: dark)')
+  // useEffect(() => {
+  //   let media = window.matchMedia('(prefers-color-scheme: dark)')
 
-    function onMediaChange() {
-      let systemTheme = media.matches ? 'dark' : 'light'
-      if (resolvedTheme === systemTheme) {
-        setTheme('light')
-      }
-    }
+  //   function onMediaChange() {
+  //     let systemTheme = media.matches ? 'dark' : 'light'
+  //     // if (resolvedTheme === systemTheme) {
+  //     //   setTheme('light')
+  //     // }
+  //   }
 
-    onMediaChange()
-    media.addEventListener('change', onMediaChange)
+  //   onMediaChange()
+  //   media.addEventListener('change', onMediaChange)
 
-    return () => {
-      media.removeEventListener('change', onMediaChange)
-    }
-  }, [resolvedTheme, setTheme])
+  //   return () => {
+  //     media.removeEventListener('change', onMediaChange)
+  //   }
+  // }, [resolvedTheme, setTheme])
 
   return null
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
-import { ThemeProvider, useTheme } from 'next-themes'
+import { ThemeProvider } from 'next-themes'
 
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -15,34 +14,9 @@ function CSPostHogProvider({ children }: { children: React.ReactNode }) {
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
 
-function ThemeWatcher() {
-  // let { resolvedTheme, setTheme } = useTheme()
-
-  // useEffect(() => {
-  //   let media = window.matchMedia('(prefers-color-scheme: dark)')
-
-  //   function onMediaChange() {
-  //     let systemTheme = media.matches ? 'dark' : 'light'
-  //     // if (resolvedTheme === systemTheme) {
-  //     //   setTheme('light')
-  //     // }
-  //   }
-
-  //   onMediaChange()
-  //   media.addEventListener('change', onMediaChange)
-
-  //   return () => {
-  //     media.removeEventListener('change', onMediaChange)
-  //   }
-  // }, [resolvedTheme, setTheme])
-
-  return null
-}
-
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" disableTransitionOnChange>
-      <ThemeWatcher />
       <CSPostHogProvider>{children}</CSPostHogProvider>
     </ThemeProvider>
   )

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -8,7 +8,10 @@ interface BackButtonProps {
 
 export const BackButton: FC<BackButtonProps> = ({ href }) => {
   return (
-    <Link className="mb-8 flex flex-row items-center" href={href}>
+    <Link
+      className="mb-8 flex flex-row items-center text-red-500 no-underline hover:text-red-500/70"
+      href={href}
+    >
       <ChevronLeft size={17} />
       Back
     </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -134,25 +134,31 @@ export const Header = forwardRef<
             href="https://twitter.com/justansub"
             target="_blank"
             rel="noreferrer"
-            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex"
+            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex dark:hover:bg-white/5 "
           >
-            <XIcon className="h-4 w-4" />
+            <XIcon className="h-4 w-4 dark:text-white" fill="currentColor" />
           </Link>
           <Link
             href="https://discord.gg/P8GXYyH3ZU"
             target="_blank"
             rel="noreferrer"
-            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex"
+            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex dark:hover:bg-white/5"
           >
-            <DiscordIcon className="h-4 w-4" />
+            <DiscordIcon
+              className="h-4 w-4 dark:text-white"
+              fill="currentColor"
+            />
           </Link>
           <Link
             href="https://github.com/ansub/ui"
             target="_blank"
             rel="noreferrer"
-            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex"
+            className="hidden items-center gap-1 rounded-lg p-2  text-sm text-gray-600 transition-all duration-300 ease-in-out hover:bg-gray-100 md:flex dark:hover:bg-white/5"
           >
-            <GitHubIcon className="h-4 w-4" />
+            <GitHubIcon
+              className="h-4 w-4 dark:text-white"
+              fill="currentColor"
+            />
           </Link>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,7 +84,7 @@ export const Header = forwardRef<
             width={100}
             height={100}
           />
-          <div className="text-md font-medium text-gray-800">
+          <div className="text-md font-medium text-gray-800 dark:text-white">
             Syntax<span className="text-[10px] font-bold text-red-500">UI</span>
           </div>
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ import XIcon from '@/icons/x'
 import DiscordIcon from '@/icons/discord'
 import Image from 'next/image'
 import { usePathname } from 'next/navigation'
+import { ThemeToggle } from './ThemeToggle'
 
 function TopLevelNavItem({
   href,
@@ -127,7 +128,7 @@ export const Header = forwardRef<
         {/* <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" /> */}
         <div className="flex items-center gap-2">
           <MobileSearch />
-          {/* <ThemeToggle /> */}
+          <ThemeToggle />
 
           <Link
             href="https://twitter.com/justansub"

--- a/src/components/Logos/Framer.tsx
+++ b/src/components/Logos/Framer.tsx
@@ -8,12 +8,10 @@ const FramerLogo = (props: SVGProps<SVGSVGElement>) => (
     height="1em"
     xmlns="http://www.w3.org/2000/svg"
     preserveAspectRatio="xMidYMid"
+    fill="currentColor"
     {...props}
   >
-    <path
-      fill="#000"
-      d="M0 0h256v128H128L0 0Zm0 128h128l128 128H128v128L0 256V128Z"
-    />
+    <path d="M0 0h256v128H128L0 0Zm0 128h128l128 128H128v128L0 256V128Z" />
   </svg>
 )
 export default FramerLogo

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -43,6 +43,10 @@ export function ThemeToggle() {
     setMounted(true)
   }, [setMounted])
 
+  useEffect(() => {
+    console.log('Theme is', resolvedTheme)
+  }, [resolvedTheme])
+
   return (
     <button
       type="button"

--- a/src/components/code/Code.tsx
+++ b/src/components/code/Code.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useContext, useEffect, useMemo, useState } from 'react'
-import { CodeGroupContext } from './CodeGroup'
+import { CodeGroupContext, useCodeGroup } from './CodeGroup'
 import { cn } from '@/lib/utils'
 import { CopyButton } from './CopyButton'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
@@ -31,7 +31,7 @@ export default function Code({
   language: string
 }) {
   const code = useMemo(() => (rawCode ?? '').trim(), [rawCode])
-  const inCodeGroup = useContext(CodeGroupContext)
+  const { inCodeGroup, hasTitle: rounded } = useCodeGroup()
   const inline = useMemo(() => {
     return code.trim().split('\n').length === 1 && !inCodeGroup
   }, [inCodeGroup, code])
@@ -52,11 +52,12 @@ export default function Code({
   return (
     <div
       className={cn(
-        'relative bg-zinc-900 pb-0',
-        inCodeGroup ? 'rounded-b-lg rounded-t-none' : 'rounded-lg',
+        'relative  border border-gray-600 bg-zinc-900 pb-0 dark:border-gray-600',
+        rounded ? 'rounded-b-lg rounded-t-none' : 'rounded-lg',
+        inCodeGroup && 'border-0',
       )}
     >
-      <CopyButton value={code} className="z-10 border-none" />
+      <CopyButton value={code} className="z-10 border-gray-600" />
       <SyntaxHighlighter language={lang} wrapLines wrapLongLines style={theme}>
         {code}
       </SyntaxHighlighter>

--- a/src/components/code/CodeGroup.tsx
+++ b/src/components/code/CodeGroup.tsx
@@ -12,7 +12,17 @@ import {
 } from 'react'
 import { Button } from '../mdx'
 
-export const CodeGroupContext = createContext(false)
+export const CodeGroupContext = createContext({
+  inCodeGroup: false,
+  hasTitle: false,
+})
+
+export function useInCodeGroup() {
+  return useContext(CodeGroupContext).inCodeGroup
+}
+export function useCodeGroup() {
+  return useContext(CodeGroupContext)
+}
 
 /**
  * This is a code group component that accepts `children` which should be a `RawCode` or a `Code` component and an optional `title: string`.
@@ -36,22 +46,37 @@ export default function CodeGroup({
   const [minimized, setMinimized] = useState<boolean | undefined>(
     noExpand ? undefined : true,
   )
-  const codeRef = useRef<HTMLDivElement>(null)
 
   return (
-    <CodeGroupContext.Provider value={true}>
+    <CodeGroupContext.Provider
+      value={{
+        inCodeGroup: true,
+        hasTitle: Boolean(title),
+      }}
+    >
       <div
         className={cn(
-          'relative mb-4 mt-8 max-h-full overflow-hidden rounded-lg transition-[max-height] duration-500',
-          minimized ? 'max-h-[300px]' : '',
+          'relative mb-4 mt-8  border-collapse overflow-hidden rounded-lg border border-gray-600 duration-500 dark:border-gray-600',
         )}
       >
         {title && (
-          <div className="border border-zinc-700  bg-zinc-800 px-5 py-3 text-xs font-semibold text-white">
+          <div
+            className={cn(
+              ' border-b border-gray-600 bg-zinc-800 px-5 py-3 text-xs font-semibold text-white',
+            )}
+          >
             {title}
           </div>
         )}
-        <div ref={codeRef}>{children}</div>
+
+        <div
+          className={cn(
+            'max-h-full transition-[max-height] ',
+            minimized ? 'max-h-[300px]' : '',
+          )}
+        >
+          {children}
+        </div>
         {!noExpand && (
           <button
             className="absolute bottom-0 block w-full rounded-2xl  bg-[#18181b50] py-2 text-sm font-medium text-white hover:text-red-500"

--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -123,7 +123,7 @@ export function ComponentPreview({
                 </TooltipTrigger>
                 <TooltipContent className="m-0 p-0 text-sm">
                   <p className="m-0 p-1">
-                    This component requires{' '}
+                    This component requires
                     <Link
                       target="_blank"
                       rel="noreferrer"
@@ -143,7 +143,7 @@ export function ComponentPreview({
                   </TooltipTrigger>
                   <TooltipContent className="m-0 p-0 text-sm">
                     <p className="m-0 p-1">
-                      This component requires{' '}
+                      This component requires
                       <Link
                         target="_blank"
                         rel="noreferrer"
@@ -263,7 +263,9 @@ function ComponentPreviewUsingCn({
     >
       <div className="flex flex-col items-center justify-between md:flex-row">
         <div className="flex w-full items-center justify-between gap-2  md:justify-start">
-          <h2 className="text-md m-0 font-medium text-gray-800">{name}</h2>
+          <h2 className="text-md m-0 font-medium text-gray-800  dark:text-gray-200">
+            {name}
+          </h2>
           <div className="flex items-center justify-center gap-x-2">
             <TooltipProvider>
               <Tooltip delayDuration={0}>
@@ -308,7 +310,7 @@ function ComponentPreviewUsingCn({
           </div>
         </div>
       </div>
-      <div className="relative rounded-md border">
+      <div className="relative rounded-md border border-gray-200 dark:border-gray-600">
         <div>
           <div
             className={cn(

--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -105,14 +105,16 @@ export function ComponentPreview({
   return (
     <div
       className={cn(
-        'group relative my-10 flex w-full max-w-5xl flex-col space-y-2',
+        'group relative my-10 flex w-full max-w-5xl flex-col space-y-2 ',
         className,
       )}
       {...props}
     >
       <div className="flex flex-col items-center justify-between md:flex-row">
         <div className="flex w-full items-center justify-between gap-2  md:justify-start">
-          <h2 className="text-md m-0 font-medium text-gray-800">{name}</h2>
+          <h2 className="text-md m-0 font-medium text-gray-800 dark:text-gray-200">
+            {name}
+          </h2>
           <div className="flex items-center justify-center gap-x-2">
             <TooltipProvider>
               <Tooltip delayDuration={0}>
@@ -165,12 +167,12 @@ export function ComponentPreview({
         />
       </div>
       {selectedTab === 'preview' && (
-        <div className="relative rounded-md border">
+        <div className="relative rounded-md border border-gray-200 dark:border-gray-600 ">
           <CopyButton value={codeString} />
           <div>
             <div
               className={cn(
-                'preview flex min-h-[250px] w-full justify-center overflow-hidden p-10',
+                'preview flex min-h-[250px] w-full justify-center overflow-hidden p-10 ',
                 {
                   'items-center': align === 'center',
                   'items-start': align === 'start',

--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -123,11 +123,12 @@ export function ComponentPreview({
                 </TooltipTrigger>
                 <TooltipContent className="m-0 p-0 text-sm">
                   <p className="m-0 p-1">
-                    This component requires
+                    This component requires{' '}
                     <Link
                       target="_blank"
                       rel="noreferrer"
                       href="https://tailwindcss.com/"
+                      className="text-red-500 no-underline hover:text-red-500"
                     >
                       Tailwind CSS
                     </Link>
@@ -139,15 +140,16 @@ export function ComponentPreview({
               <TooltipProvider>
                 <Tooltip delayDuration={0}>
                   <TooltipTrigger>
-                    <FramerLogo />
+                    <FramerLogo className="text-black dark:text-white" />
                   </TooltipTrigger>
                   <TooltipContent className="m-0 p-0 text-sm">
                     <p className="m-0 p-1">
-                      This component requires
+                      This component requires{' '}
                       <Link
                         target="_blank"
                         rel="noreferrer"
                         href="https://www.framer.com/motion/"
+                        className="text-red-500 no-underline hover:text-red-500"
                       >
                         Framer Motion
                       </Link>
@@ -279,6 +281,7 @@ function ComponentPreviewUsingCn({
                       target="_blank"
                       rel="noreferrer"
                       href="https://tailwindcss.com/"
+                      className="text-red-500 no-underline hover:text-red-500"
                     >
                       Tailwind CSS
                     </Link>
@@ -290,7 +293,7 @@ function ComponentPreviewUsingCn({
               <TooltipProvider>
                 <Tooltip delayDuration={0}>
                   <TooltipTrigger>
-                    <FramerLogo />
+                    <FramerLogo className="text-black dark:text-white" />
                   </TooltipTrigger>
                   <TooltipContent className="m-0 p-0 text-sm">
                     <p className="m-0 p-1">
@@ -299,6 +302,7 @@ function ComponentPreviewUsingCn({
                         target="_blank"
                         rel="noreferrer"
                         href="https://www.framer.com/motion/"
+                        className="text-red-500 no-underline hover:text-red-500"
                       >
                         Framer Motion
                       </Link>

--- a/src/components/code/CopyButton.tsx
+++ b/src/components/code/CopyButton.tsx
@@ -25,7 +25,7 @@ export function CopyButton({
     <button
       type="button"
       className={cn(
-        `group/button absolute right-2 top-2 overflow-hidden rounded-full border py-1 pl-2 pr-3 text-2xs font-medium backdrop-blur transition focus:opacity-100 ${className}`,
+        `group/button absolute right-2 top-2 overflow-hidden rounded-full border border-gray-200 py-1 pl-2 pr-3 text-2xs font-medium backdrop-blur transition focus:opacity-100 dark:border-gray-600 ${className}`,
         copied
           ? 'bg-red-400/10 ring-1 ring-inset ring-red-400/20'
           : 'bg-white/5 hover:bg-white/7.5 dark:bg-white/2.5 dark:hover:bg-white/5',

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -132,7 +132,7 @@ export function Property({
 
 export function Preview({ children }: { children: React.ReactNode }) {
   return (
-    <div className="group inline-flex w-full items-center justify-center gap-3 rounded-lg border py-8 sm:max-lg:block">
+    <div className="group inline-flex w-full items-center justify-center gap-3 rounded-lg border border-gray-200 py-8 sm:max-lg:block dark:border-gray-600">
       {children}
     </div>
   )

--- a/src/components/reusable/AnimatedTabs.tsx
+++ b/src/components/reusable/AnimatedTabs.tsx
@@ -72,7 +72,7 @@ const AnimatedTabs = ({
     <div
       className={
         (center ? 'justify-center ' : '') +
-        'flex  items-center gap-2 border-gray-500/25 bg-white pb-1 w-full justify-end '
+        'flex  w-full items-center justify-end  gap-2 border-gray-500/25 pb-1 '
       }
     >
       {tabs?.map((tab, index) => (

--- a/src/showcase/animations/SkewedInfiniteScroll.tsx
+++ b/src/showcase/animations/SkewedInfiniteScroll.tsx
@@ -20,12 +20,18 @@ const SkewedInfiniteScroll: FC = () => {
   return (
     <div>
       <div className="flex items-center justify-center">
-        <div className="relative w-full max-w-screen-lg overflow-hidden">
-          <div className="pointer-events-none absolute -top-1 z-10 h-20 w-full bg-gradient-to-b from-white"></div>
-          <div className="pointer-events-none absolute -bottom-1 z-10 h-20 w-full bg-gradient-to-t from-white"></div>
-          <div className="pointer-events-none absolute -left-1 z-10 h-full w-20 bg-gradient-to-r from-white"></div>
-          <div className="pointer-events-none absolute -right-1 z-10 h-full w-20 bg-gradient-to-l from-white"></div>
-
+        <div
+          className="relative w-full max-w-screen-lg overflow-hidden"
+          style={{
+            maskComposite: 'intersect',
+            maskImage: `
+              linear-gradient(to right,  transparent, black 5rem),
+              linear-gradient(to left,   transparent, black 5rem),
+              linear-gradient(to bottom, transparent, black 5rem),
+              linear-gradient(to top,    transparent, black 5rem)
+            `,
+          }}
+        >
           <div className="mx-auto grid h-[250px] w-[300px] animate-skew-scroll grid-cols-1 gap-5 sm:w-[600px] sm:grid-cols-2">
             {items.map((item) => (
               <div

--- a/src/showcase/animations/SkewedInfiniteScroll.tsx
+++ b/src/showcase/animations/SkewedInfiniteScroll.tsx
@@ -36,7 +36,7 @@ const SkewedInfiniteScroll: FC = () => {
             {items.map((item) => (
               <div
                 key={item.id}
-                className="flex cursor-pointer items-center space-x-2 rounded-md border border-gray-100 px-5 shadow-md transition-all hover:-translate-y-1 hover:translate-x-1 hover:scale-[1.025] hover:shadow-xl"
+                className="flex cursor-pointer items-center space-x-2 rounded-md border border-gray-100 px-5 shadow-md transition-all hover:-translate-y-1 hover:translate-x-1 hover:scale-[1.025] hover:shadow-xl dark:border-gray-800"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/src/showcase/components/features/FeaturesGrid.tsx
+++ b/src/showcase/components/features/FeaturesGrid.tsx
@@ -87,10 +87,10 @@ const FeaturesGrid = () => {
                 className="mb-2 h-5 w-5 text-red-500"
                 aria-hidden="true"
               />
-              <div className="text-md inline font-semibold text-gray-800">
+              <div className="text-md inline font-semibold text-gray-800 dark:text-gray-100">
                 {feature.name}
               </div>{' '}
-              <div className="inline max-w-xs text-sm text-gray-700">
+              <div className="inline max-w-xs text-sm text-gray-700 dark:text-gray-300">
                 {feature.description}
               </div>
             </div>

--- a/src/showcase/components/features/FeaturesWithHeading.tsx
+++ b/src/showcase/components/features/FeaturesWithHeading.tsx
@@ -62,13 +62,13 @@ const FeaturesGrid = () => {
         {FeaturesData.map((feature) => {
           return (
             <div key={feature.id} className="width-fit text-left">
-              <div className="mb-2 w-fit rounded-lg bg-red-500 p-1 text-center text-white">
+              <div className="mb-2 w-fit rounded-lg bg-red-500 p-1 text-center text-white ">
                 {feature.icon}
               </div>
-              <div className="text-md mb-1 font-semibold text-gray-900">
+              <div className="text-md mb-1 font-semibold text-gray-900 dark:text-gray-100">
                 {feature.name}
               </div>
-              <div className="font-regular max-w-sm text-xs text-gray-600">
+              <div className="font-regular max-w-sm text-xs text-gray-600  dark:text-gray-400">
                 {feature.description}
               </div>
             </div>
@@ -82,10 +82,10 @@ const FeaturesGrid = () => {
 const FeaturesWithHeading = () => {
   return (
     <div className="my-12 flex w-full flex-col items-center justify-center">
-      <h1 className="mb-2 max-w-3xl text-center text-2xl font-semibold tracking-tighter text-gray-900 md:text-3xl">
+      <h1 className="mb-2 max-w-3xl text-center text-2xl font-semibold tracking-tighter text-gray-900 md:text-3xl dark:text-gray-100">
         SyntaxUI is not like any other component library.
       </h1>
-      <p className="max-w-sm text-center text-sm text-gray-600">
+      <p className="max-w-sm text-center text-sm text-gray-600 dark:text-gray-400">
         SyntaxUI is a free to use, customizable, and highly customizable UI
         component library.
       </p>

--- a/src/showcase/components/features/HoverSpring.tsx
+++ b/src/showcase/components/features/HoverSpring.tsx
@@ -63,13 +63,13 @@ const HoverSpring = () => {
                   src={project.image}
                   width={30}
                   height={30}
-                  className="mb-3 rounded-lg"
+                  className="mb-3 rounded-lg border-gray-400 dark:border"
                   alt={project.name}
                 />
-                <div className="mb-1 text-sm font-medium text-gray-900">
+                <div className="mb-1 text-sm font-medium text-gray-900 dark:text-gray-100">
                   {project.name}
                 </div>
-                <div className="max-w-[250px] text-sm font-normal text-gray-500">
+                <div className="max-w-[250px] text-sm font-normal text-gray-500 dark:text-gray-500">
                   {project.description}
                 </div>
               </a>

--- a/src/showcase/components/footer/MinimalSocialsFooter.tsx
+++ b/src/showcase/components/footer/MinimalSocialsFooter.tsx
@@ -51,7 +51,10 @@ const MinimalSocialsFooter = () => {
     <div className="flex w-full flex-col items-center justify-between gap-5 border-t border-gray-900/5 pt-8 sm:flex-row dark:border-white/5">
       <p className="text-xs text-gray-600 dark:text-gray-400">
         Copyright © {new Date().getFullYear()}{' '}
-        <a href="https://twitter.com/justansub" className="underline">
+        <a
+          href="https://twitter.com/justansub"
+          className=" text-red-500 underline hover:text-red-500 "
+        >
           SyntaxUI
         </a>{' '}
       </p>

--- a/src/showcase/components/footer/TwoColumnFooter.tsx
+++ b/src/showcase/components/footer/TwoColumnFooter.tsx
@@ -45,17 +45,17 @@ const TwoColumnFooter = () => {
               alt="logo"
               className="h-7 w-auto"
             />
-            <p className="text-md max-w-xs leading-6 text-gray-700">
+            <p className="text-md max-w-xs leading-6 text-gray-700 dark:text-gray-300">
               Not your average component library - build faster, launch sooner.
             </p>
-            <div className="flex space-x-6 text-sm text-gray-700">
+            <div className="flex space-x-6 text-sm text-gray-700  dark:text-gray-300">
               <div>Made with ❤️ by Ansub.</div>
             </div>
           </div>
           {/* Navigations */}
           <div className="mt-16 grid grid-cols-2 gap-14 md:grid-cols-2 lg:mt-0 xl:col-span-2">
             <div className="md:mt-0">
-              <h3 className="text-sm font-semibold leading-6 text-gray-900">
+              <h3 className="text-sm font-semibold leading-6 text-gray-900  dark:text-gray-200">
                 Connect
               </h3>
               <div className="mt-6 space-y-4">
@@ -65,7 +65,7 @@ const TwoColumnFooter = () => {
                       href={item.href}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-sm leading-6 text-gray-700 hover:text-gray-900"
+                      className="text-sm leading-6 text-gray-700 hover:text-gray-900 dark:text-gray-500 hover:dark:text-gray-200"
                     >
                       {item.name}
                     </a>
@@ -75,7 +75,7 @@ const TwoColumnFooter = () => {
             </div>
             <div>
               <div>
-                <h3 className="text-sm font-semibold leading-6 text-gray-900">
+                <h3 className="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200">
                   Company
                 </h3>
                 <div className="mt-6 space-y-4">
@@ -83,7 +83,7 @@ const TwoColumnFooter = () => {
                     <div key={item.name}>
                       <a
                         href={item.href}
-                        className="text-sm leading-6 text-gray-700 hover:text-gray-900"
+                        className="text-sm leading-6 text-gray-700 hover:text-gray-900 dark:text-gray-500 hover:dark:text-gray-200"
                       >
                         {item.name}
                       </a>
@@ -94,8 +94,8 @@ const TwoColumnFooter = () => {
             </div>
           </div>
         </div>
-        <div className="mt-16 border-t border-gray-900/10 pt-8 sm:mt-20 lg:mt-24">
-          <p className="text-xs leading-5 text-gray-700">
+        <div className="mt-16 border-t border-gray-900/10 pt-8 sm:mt-20 lg:mt-24 dark:border-gray-100/10">
+          <p className="text-xs leading-5 text-gray-700 dark:text-gray-300">
             &copy; 2024 SyntaxUI. All rights reserved.
           </p>
         </div>

--- a/src/showcase/components/input/TagInput.tsx
+++ b/src/showcase/components/input/TagInput.tsx
@@ -69,7 +69,7 @@ const TagInput: React.FC = () => {
   }
 
   return (
-    <div className="flex w-full flex-wrap items-center rounded-lg border p-2">
+    <div className="flex w-full flex-wrap items-center rounded-lg border border-gray-200 p-2 dark:border-gray-600">
       <div
         className="flex w-full flex-wrap overflow-y-auto"
         style={{ maxHeight: '300px' }}
@@ -91,7 +91,7 @@ const TagInput: React.FC = () => {
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           onBlur={(e) => handleBlur(e)}
-          className="my-1 flex-1 text-sm outline-none"
+          className="my-1 flex-1 bg-transparent text-sm outline-none"
           placeholder="Type keyword and press Enter..."
         />
       </div>

--- a/src/showcase/components/pricing/Pricing.tsx
+++ b/src/showcase/components/pricing/Pricing.tsx
@@ -105,7 +105,7 @@ const Pricing = () => {
       {pricingPlans.map((plan, index) => (
         <div
           key={index}
-          className="w-full rounded-xl border-[1px] border-gray-300 p-6 text-left"
+          className="w-full rounded-xl border-[1px] border-gray-300 p-6 text-left dark:border-gray-600"
         >
           <p className="mb-1 mt-0 text-sm font-medium uppercase text-red-500">
             {plan.name}

--- a/src/showcase/components/pricing/Pricing.tsx
+++ b/src/showcase/components/pricing/Pricing.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/lib/utils'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Check } from 'lucide-react'
 import { useState } from 'react'
@@ -59,36 +60,38 @@ const Pricing = () => {
   const Heading = () => (
     <div className="relative z-10 my-12 flex flex-col items-center justify-center gap-4">
       <div className="flex w-full flex-col items-start justify-center space-y-4 md:items-center">
-        <div className="mb-2 inline-block rounded-full bg-red-100 px-2 py-[0.20rem] text-xs font-medium uppercase text-red-500">
+        <div className="mb-2 inline-block rounded-full bg-red-100 px-2 py-[0.20rem] text-xs font-medium uppercase text-red-500 dark:bg-red-200">
           {' '}
           Pricing
         </div>
-        <p className="mt-2 text-3xl font-bold tracking-tight text-gray-800 sm:text-4xl">
+        <p className="mt-2 text-3xl font-bold tracking-tight text-gray-800 sm:text-4xl dark:text-gray-200">
           Fair pricing, unfair advantage.
         </p>
-        <p className="text-md max-w-xl text-gray-700 md:text-center">
+        <p className="text-md max-w-xl text-gray-700 md:text-center dark:text-gray-300">
           Get started with Acme today and take your business to the next level.
         </p>
       </div>
       <div className="flex items-center justify-center gap-3">
         <button
           onClick={() => setBillingCycle('M')}
-          className={`rounded-lg px-4 py-2 text-sm font-medium ${
+          className={cn(
+            `rounded-lg px-4 py-2 text-sm font-medium `,
             billingCycle === 'M'
-              ? 'relative bg-red-500 text-white'
-              : 'text-gray-700 hover:bg-red-100'
-          }`}
+              ? 'relative bg-red-500 text-white '
+              : 'text-gray-700 hover:bg-red-100 dark:text-gray-300 dark:hover:text-black',
+          )}
         >
           Monthly
           {billingCycle === 'M' && <BackgroundShift shiftKey="monthly" />}
         </button>
         <button
           onClick={() => setBillingCycle('A')}
-          className={`rounded-lg px-4 py-2 text-sm font-medium ${
+          className={cn(
+            `rounded-lg px-4 py-2 text-sm font-medium `,
             billingCycle === 'A'
-              ? 'relative bg-red-500 text-white'
-              : 'text-gray-700 hover:bg-red-100'
-          }`}
+              ? 'relative bg-red-500 text-white '
+              : 'text-gray-700 hover:bg-red-100 dark:text-gray-300 dark:hover:text-black',
+          )}
         >
           Annual
           {billingCycle === 'A' && <BackgroundShift shiftKey="annual" />}
@@ -102,7 +105,7 @@ const Pricing = () => {
       {pricingPlans.map((plan, index) => (
         <div
           key={index}
-          className="w-full rounded-xl border-[1px] border-gray-300 bg-white p-6 text-left"
+          className="w-full rounded-xl border-[1px] border-gray-300 p-6 text-left"
         >
           <p className="mb-1 mt-0 text-sm font-medium uppercase text-red-500">
             {plan.name}
@@ -115,7 +118,7 @@ const Pricing = () => {
                 initial={{ y: -50, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: 'spring', stiffness: 100 }}
-                className="my-0 text-3xl font-semibold text-gray-900"
+                className="my-0 text-3xl font-semibold text-gray-900 dark:text-gray-100"
               >
                 <span>
                   ${billingCycle === 'M' ? plan.monthlyPrice : plan.annualPrice}
@@ -147,7 +150,7 @@ const Pricing = () => {
   )
 
   return (
-    <section className="relative w-full overflow-hidden bg-white py-12 text-black lg:px-2 lg:py-12">
+    <section className="relative w-full overflow-hidden  py-12 text-black lg:px-2 lg:py-12">
       <Heading />
       <PricingCards />
     </section>

--- a/src/showcase/components/tabs/ButtonShapeTabs.tsx
+++ b/src/showcase/components/tabs/ButtonShapeTabs.tsx
@@ -16,7 +16,9 @@ const Tab = ({ text, selected, setSelected }: TabProps) => {
     <button
       onClick={() => setSelected(text)}
       className={`${
-        selected ? 'text-white' : 'text-gray-500 hover:text-gray-900'
+        selected
+          ? 'text-white'
+          : 'text-gray-500 hover:text-gray-900 dark:hover:text-gray-100'
       } relative rounded-md px-2 py-1 text-sm font-medium transition-colors`}
     >
       <span className="relative z-10">{text}</span>

--- a/src/showcase/components/tabs/IconTabs.tsx
+++ b/src/showcase/components/tabs/IconTabs.tsx
@@ -57,7 +57,9 @@ const Tab = ({ text, selected, setSelected, index, children }: TabProps) => {
       onClick={() => setSelected(tabs[index])}
       transition={transition}
       className={`${
-        selected ? 'bg-red-500/15 text-red-500 ' : ' hover:text-gray-900'
+        selected
+          ? 'bg-red-500/15 text-red-500 '
+          : ' hover:text-gray-900 dark:hover:text-gray-100'
       } relative flex items-center rounded-full px-4 py-2 text-sm font-medium text-gray-500 transition-colors duration-300 focus-within:outline-red-500/50`}
     >
       {children}
@@ -88,7 +90,7 @@ const IconTabs = ({ center }: { center?: boolean }) => {
     <div
       className={` ${
         center ? 'justify-center ' : ''
-      } border-black-500/25 mb-8 flex flex-wrap items-center gap-2 border-b pb-2`}
+      } mb-8 flex flex-wrap items-center gap-2 border-b border-gray-200 pb-2 dark:border-gray-600`}
     >
       {tabs.map((tab, index) => (
         <Tab

--- a/src/showcase/components/tabs/LineTabs.tsx
+++ b/src/showcase/components/tabs/LineTabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cn } from '@/lib/utils'
 import { motion } from 'framer-motion'
 import { useState } from 'react'
 
@@ -17,7 +18,9 @@ const Tab = ({ text, selected, setSelected, customID }: TabProps) => {
     <button
       onClick={() => setSelected(text)}
       className={` ${
-        selected ? 'text-red-500' : ' hover:text-gray-900'
+        selected
+          ? 'text-red-500'
+          : ' hover:text-gray-900 dark:hover:text-gray-100'
       } relative rounded-md  px-2 py-1 text-sm font-medium text-gray-500 transition-colors duration-300 focus-within:outline-red-500/50`}
     >
       <span className="relative z-10">{text}</span>
@@ -43,9 +46,10 @@ const LineTabs = ({ center, customID }: LineTabProps) => {
   const [selected, setSelected] = useState<string>(tabs[0])
   return (
     <div
-      className={` ${
-        center ? 'justify-center ' : ''
-      } border-black-500/25 mb-8 flex flex-wrap items-center gap-2 border-b`}
+      className={cn(
+        'mb-8 flex flex-wrap items-center gap-2 border-b border-gray-200 dark:border-gray-600',
+        center && 'justify-center',
+      )}
     >
       {tabs.map((tab) => (
         <Tab

--- a/src/showcase/components/tabs/SimpleTabs.tsx
+++ b/src/showcase/components/tabs/SimpleTabs.tsx
@@ -1,7 +1,57 @@
 'use client'
 
-import { Tabs } from '@/components/reusable/Tabs'
 import { useState } from 'react'
+
+type Tab = {
+  id: string
+  label: string
+}
+
+type TabProps = {
+  label: string
+  isActive: boolean
+  onClick: () => void
+}
+
+const Tab = ({ label, isActive, onClick }: TabProps) => {
+  return (
+    <div
+      className={`
+        ${
+          isActive
+            ? 'border-b-[3px] border-red-500 pb-2 font-semibold '
+            : 'cursor-pointer hover:bg-transparent'
+        }
+        text-decoration-none mx-2 justify-start rounded-t-md px-2 py-2 text-sm font-medium 
+      `}
+      onClick={onClick}
+    >
+      {label}
+    </div>
+  )
+}
+
+type TabsProps = {
+  tabs: Tab[]
+  activeTab: string
+  onTabClick: (tabId: string) => void
+  center?: boolean
+}
+
+export const Tabs = ({ tabs, activeTab, onTabClick, center }: TabsProps) => {
+  return (
+    <div className="mb-4 flex w-full">
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.id}
+          label={tab.label}
+          isActive={activeTab === tab.id}
+          onClick={() => onTabClick(tab.id)}
+        />
+      ))}
+    </div>
+  )
+}
 
 const SimpleTabs = () => {
   const [activeTab, setActiveTab] = useState('ansub')

--- a/src/showcase/components/testimonial/TestimonialGrid.tsx
+++ b/src/showcase/components/testimonial/TestimonialGrid.tsx
@@ -16,7 +16,7 @@ const TestimonialCard: FC<TestimonalCardProps> = ({
 }) => {
   return (
     <div
-      className={`card-shadow relative flex h-auto max-w-[22rem] flex-col items-start justify-center overflow-hidden rounded-2xl border border-[#F5F5F5] bg-white p-5 shadow-sm`}
+      className={`card-shadow dark:border-neutral-90 relative flex h-auto max-w-[22rem] flex-col items-start justify-center overflow-hidden rounded-2xl border border-neutral-100 p-5 shadow-sm dark:border-neutral-800 `}
     >
       <div className="absolute right-0 top-0 h-24 w-24 rounded-2xl bg-gradient-to-r from-[#fb3a5d]  to-[#fb3a5d] opacity-20 blur-3xl"></div>
       <div className="mb-0 flex h-fit flex-row items-center gap-3">
@@ -28,13 +28,15 @@ const TestimonialCard: FC<TestimonalCardProps> = ({
           height={80}
         />
         <div className="mb-0 flex h-fit flex-col items-start">
-          <h3 className="m-0 text-base font-medium text-gray-900">{name}</h3>
-          <p className="font-regular m-0 text-center text-sm text-gray-600">
+          <h3 className="m-0 text-base font-medium text-gray-900 dark:text-gray-100">
+            {name}
+          </h3>
+          <p className="font-regular m-0 text-center text-sm text-gray-600 dark:text-gray-400">
             {profession}
           </p>
         </div>
       </div>
-      <p className="mb-0 mt-3 text-left text-sm font-light text-gray-600 md:text-base">
+      <p className="mb-0 mt-3 text-left text-sm font-light text-gray-600 md:text-base dark:text-gray-400">
         {description}
       </p>
     </div>
@@ -44,10 +46,10 @@ const TestimonialCard: FC<TestimonalCardProps> = ({
 const Testimonals = () => {
   return (
     <div className="flex flex-col items-center justify-center gap-5 py-12">
-      <h1 className="mb-1 max-w-2xl text-center text-2xl font-semibold tracking-tighter text-gray-900 md:text-4xl">
+      <h1 className="mb-1 max-w-2xl text-center text-2xl font-semibold tracking-tighter text-gray-900 md:text-4xl dark:text-gray-100">
         Why people love SyntaxUI
       </h1>
-      <p className="max-w-2xl text-center text-sm font-light text-gray-600 md:text-base">
+      <p className="max-w-2xl text-center text-sm font-light text-gray-600 md:text-base dark:text-gray-400">
         Choose the Perfect Plan to Fit Your Needs - From Individual Clinicians
         to Large Healthcare Organizations
       </p>
@@ -56,7 +58,7 @@ const Testimonals = () => {
           <TestimonialCard
             name="Ethan Pollack"
             description="I've been using SyntaxUI for a few months now and I'm really impressed with the results. The components are easy to use and the documentation is great."
-            profession="App Developer"
+            profession="Software Developer"
             image="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde"
           />
           <TestimonialCard

--- a/src/showcase/effects/ImageFade.tsx
+++ b/src/showcase/effects/ImageFade.tsx
@@ -7,9 +7,11 @@ const ImageFade: FC = () => {
         <img
           src="https://dashboardsdesign.com/img/dashboards/dashboard-05-custom.png"
           alt="hero-section"
-          className="h-full w-full rounded-lg border object-cover md:w-[1300px]"
+          className="h-full w-full rounded-lg object-cover md:w-[1300px]"
+          style={{
+            maskImage: `linear-gradient(to top, transparent, black 20%)`,
+          }}
         />
-        <div className="from-1% absolute inset-0 bg-gradient-to-t from-white to-35%" />
       </div>
     </div>
   )

--- a/src/showcase/effects/gradients/GradientCards.tsx
+++ b/src/showcase/effects/gradients/GradientCards.tsx
@@ -1,4 +1,5 @@
 'use client'
+import Card from '@/showcase/ui-group/Card'
 import { motion } from 'framer-motion'
 import { Check, Copy } from 'lucide-react'
 import { useState } from 'react'
@@ -54,19 +55,12 @@ const GradientCards = () => {
     <div>
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item, index) => (
-          <motion.div
-            key={index}
-            className="group no-underline"
-            whileTap={{ scale: 0.95 }}
-          >
-            <div
-              className="overflow group relative rounded-xl border border-gray-200 transition-all ease-in-out hover:cursor-pointer"
-              onClick={() => copyGradient(item.gradient)}
-            >
+          <button key={index} onClick={() => copyGradient(item.gradient)}>
+            <Card title={item.title}>
               <div
-                className={`relative flex h-[9rem] items-center justify-center rounded-t-xl border-b text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem] ${item.gradient}`}
+                className={`relative flex h-full w-full items-center justify-center ${item.gradient}`}
               >
-                <div className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                <div className="inset-0 flex items-center justify-center opacity-0 transition-opacity duration-300 group-hover:opacity-100">
                   {copied ? (
                     <Check className="text-2xl text-white" />
                   ) : (
@@ -74,11 +68,8 @@ const GradientCards = () => {
                   )}
                 </div>
               </div>
-              <div className="w-full p-4 text-sm font-medium text-gray-800">
-                {item.title}
-              </div>
-            </div>
-          </motion.div>
+            </Card>
+          </button>
         ))}
       </div>
     </div>

--- a/src/showcase/ui-group/AnimationCards.tsx
+++ b/src/showcase/ui-group/AnimationCards.tsx
@@ -1,6 +1,7 @@
 import SkewedInfiniteScroll from '@/showcase/animations/SkewedInfiniteScroll'
 import Link from 'next/link'
 import { HoverTadaButton } from '@/showcase/animations/hover/HoverTadaButton'
+import Card from './Card'
 
 const data = [
   {
@@ -23,14 +24,7 @@ const AnimationCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item) => (
           <Link href={item.link} key={item.id}>
-            <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
-              <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
-                {item.component}
-              </div>
-              <div className="w-full p-4 text-sm font-medium text-gray-800">
-                {item.title}
-              </div>
-            </div>
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/ButtonCards.tsx
+++ b/src/showcase/ui-group/ButtonCards.tsx
@@ -8,6 +8,7 @@ import ShimmerButton from '@/showcase/components/button/ShimmerButton'
 import ShineButton from '@/showcase/components/button/ShineButton'
 import StitchesButton from '@/showcase/components/button/StitchesButton'
 import TextRevealButton from '../components/button/TextRevealButton'
+import Card from './Card'
 
 const data = [
   {
@@ -63,7 +64,7 @@ const ButtonCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item, index) => (
           <Link href={item.link} key={index} className="no-underline">
-            <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
+            {/* <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
               <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
                 {item.component}
               </div>
@@ -72,7 +73,8 @@ const ButtonCards = () => {
                   {item.title}
                 </div>
               </div>
-            </div>
+            </div> */}
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/Card.tsx
+++ b/src/showcase/ui-group/Card.tsx
@@ -1,0 +1,18 @@
+export default function Card({
+  children,
+  title,
+}: {
+  children: React.ReactNode
+  title: string
+}) {
+  return (
+    <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer dark:border-transparent dark:ring-zinc-700">
+      <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem] dark:border-zinc-700 dark:bg-white/5 dark:group-hover:bg-white/10">
+        {children}
+      </div>
+      <div className="w-full p-4 text-sm font-medium text-gray-800 dark:text-white">
+        {title}
+      </div>
+    </div>
+  )
+}

--- a/src/showcase/ui-group/ComponentCards.tsx
+++ b/src/showcase/ui-group/ComponentCards.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import HeartbeatButton from '../components/button/HeartbeatButton'
 import AnimatedLogoCloud from '../components/logo-cloud/AnimatedLogoCloud'
+import Card from './Card'
 
 const data = [
   {
@@ -70,24 +71,19 @@ const ComponentCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item, index) => (
           <Link href={item.link} key={index} className="no-underline">
-            <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
-              <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
-                {item.image ? (
-                  <Image
-                    width={200}
-                    height={200}
-                    src={item.image}
-                    alt={item.title}
-                    className="h-auto w-[150px] duration-300 ease-in-out group-hover:scale-110 md:w-[200px]"
-                  />
-                ) : item.component ? (
-                  item.component
-                ) : null}
-              </div>
-              <div className="w-full p-4 text-sm font-medium text-gray-800">
-                {item.title}
-              </div>
-            </div>
+            <Card title={item.title}>
+              {item.image ? (
+                <Image
+                  width={200}
+                  height={200}
+                  src={item.image}
+                  alt={item.title}
+                  className="h-auto w-[150px] duration-300 ease-in-out group-hover:scale-110 md:w-[200px]"
+                />
+              ) : item.component ? (
+                item.component
+              ) : null}
+            </Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/EffectCards.tsx
+++ b/src/showcase/ui-group/EffectCards.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
+import Card from './Card'
 
 const data = [
   {
@@ -23,20 +24,15 @@ const EffectCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item) => (
           <Link href={item.link} key={item.id}>
-            <div className="overflow group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
-              <div className="flex h-[9rem] items-center justify-center rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
-                <Image
-                  width={200}
-                  height={200}
-                  src={item.image}
-                  alt={item.title}
-                  className="h-auto w-[150px] duration-300 ease-in-out group-hover:scale-110"
-                />
-              </div>
-              <div className="w-full p-4 text-sm font-medium text-gray-800">
-                {item.title}
-              </div>
-            </div>
+            <Card title={item.title}>
+              <Image
+                width={200}
+                height={200}
+                src={item.image}
+                alt={item.title}
+                className="h-auto w-[150px] duration-300 ease-in-out group-hover:scale-110 md:w-[200px]"
+              />
+            </Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/HoverAnimationCards.tsx
+++ b/src/showcase/ui-group/HoverAnimationCards.tsx
@@ -3,6 +3,7 @@ import { HoverTadaButton } from '@/showcase/animations/hover/HoverTadaButton'
 import { HoverJiggleButton } from '@/showcase/animations/hover/HoverJiggleButton'
 import { HoverPopButton } from '@/showcase/animations/hover/HoverPopButton'
 import { HoverVibrateButton } from '@/showcase/animations/hover/HoverVibrateButton'
+import Card from './Card'
 
 const data = [
   {
@@ -37,14 +38,15 @@ const HoverAnimationCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item) => (
           <Link href={item.link} key={item.id} className="no-underline">
-            <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
+            {/* <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
               <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
                 {item.component}
               </div>
               <div className="w-full p-4 text-sm font-medium text-gray-800">
                 {item.title}
               </div>
-            </div>
+            </div> */}
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/LoaderCards.tsx
+++ b/src/showcase/ui-group/LoaderCards.tsx
@@ -10,6 +10,7 @@ import ClassicLoader from '@/showcase/components/loaders/ClassicLoader'
 import BounceLoader from '@/showcase/components/loaders/BounceLoader'
 import NeonGlowLoader from '@/showcase/components/loaders/NeonGlowLoader'
 import PulsatingGradientLoader from '@/showcase/components/loaders/PulsatingGradientLoader'
+import Card from './Card'
 
 interface LoaderCardProps {
   title: string
@@ -80,14 +81,15 @@ export default function LoaderCards() {
         .filter((item) => !item.hide)
         .map((item, i) => (
           <Link href={item.link} key={i}>
-            <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
+            {/* <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
               <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
                 {item.component}
               </div>
               <div className="w-full p-4 text-sm font-medium text-gray-800">
                 {item.title}
               </div>
-            </div>
+            </div> */}
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
     </div>

--- a/src/showcase/ui-group/TextCards.tsx
+++ b/src/showcase/ui-group/TextCards.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { TextTicker } from '../components/text/text-ticker/TextTicker'
+import Card from './Card'
 
 interface ToggleCardProps {
   title: string
@@ -21,14 +22,15 @@ const ToggleCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item, i) => (
           <Link href={item.link} key={i} className="no-underline">
-            <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
+            {/* <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
               <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
                 {item.component}
               </div>
               <div className="w-full p-4 text-sm font-medium text-gray-800">
                 {item.title}
               </div>
-            </div>
+            </div> */}
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
       </div>

--- a/src/showcase/ui-group/ToggleCards.tsx
+++ b/src/showcase/ui-group/ToggleCards.tsx
@@ -4,6 +4,7 @@ import SimpleToggle from '@/showcase/components/toggle/SimpleToggle'
 import Link from 'next/link'
 import IconToggle from '@/showcase/components/toggle/IconToggle'
 import SlideToggle from '../components/toggle/SlideToggle'
+import Card from './Card'
 
 interface ToggleCardProps {
   title: string
@@ -45,14 +46,15 @@ const ButtonCards = () => {
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {data.map((item, i) => (
           <Link href={item.link} key={i} className="no-underline">
-            <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
+            {/* <div className="overflow group group rounded-xl border border-white ring-1 ring-zinc-200 transition-all ease-in-out hover:cursor-pointer">
               <div className="flex h-[9rem] items-center justify-center overflow-hidden rounded-t-xl border-b bg-gray-50 text-xs text-gray-400 transition-all ease-in-out group-hover:bg-gray-100 md:h-[12rem]">
                 {item.component}
               </div>
               <div className="w-full p-4 text-sm font-medium text-gray-800">
                 {item.title}
               </div>
-            </div>
+            </div> */}
+            <Card title={item.title}>{item.component}</Card>
           </Link>
         ))}
       </div>


### PR DESCRIPTION
## Description

I added in dark theme support to the site :)

## Related Issue

Fixes #175 

## Proposed Changes

- cleaned up `src/app/providers.tsx` by removing the `ThemeWatcher` component
  - this stopped dark theme from being applied
- added `ThemeToggle` back into `src/components/Header.tsx`
- added a new `Card` component to `ui-group` that is used in all `ui-group`s and `GradientCards`
  - this same format is used for all of the cards around the site so I grouped it so that I only had to add the dark-theme support for all cards in one place
- i also modified many of the showcase items to add dark theme support
  - primarily changes container items (headers, features, footers, tabs, etc) where white background and black borders are set directly
  - most component items (buttons, toggles, text, etc) were left alone because they are not generally themed items
  - i changed `SkewedInfiniteScroll` and `ImageFade` to use `maskImage` which fades to transparency instead of span gradients which fade to white

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

## Additional Notes

The `typography.ts` file has a lot of say over how things are styled when in dark theme (specifically the `--tw-prose-invert-...` section). We should decide what we would like to use this for.