### PR TITLE
feat: Default theme on first visit

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { ThemeProvider } from 'next-themes'
+import { ThemeProvider, useTheme } from 'next-themes'
+import { useEffect } from 'react'
 
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -13,10 +14,33 @@ if (typeof window !== 'undefined') {
 function CSPostHogProvider({ children }: { children: React.ReactNode }) {
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
+function ThemeWatcher() {
+  let { resolvedTheme, setTheme } = useTheme()
 
+  useEffect(() => {
+    let media = window.matchMedia('(prefers-color-scheme: dark)')
+
+    function onMediaChange() {
+      let systemTheme = media.matches ? 'dark' : 'light'
+      if (resolvedTheme === systemTheme) {
+        setTheme(systemTheme)
+      }
+    }
+
+    onMediaChange()
+    media.addEventListener('change', onMediaChange)
+
+    return () => {
+      media.removeEventListener('change', onMediaChange)
+    }
+  }, [resolvedTheme, setTheme])
+
+  return null
+}
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" disableTransitionOnChange>
+      <ThemeWatcher />
       <CSPostHogProvider>{children}</CSPostHogProvider>
     </ThemeProvider>
   )


### PR DESCRIPTION
## Description

I added back the ThemeWatcher component to default to the system theme on first visit to the website. 

## Proposed Changes

- Adding ThemeWatcher component in  `src/app/providers.tsx`  for default theme.

## Screenshots

![image](https://github.com/SyntaxUI/syntaxui/assets/49506854/89ef1479-7195-4493-8d2a-9028b78e5c58)

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)