### PR TITLE
[Feature]: Removed Framer-Motion from Icon Toggle

### DIFF
--- a/credits.md
+++ b/credits.md
@@ -17,4 +17,3 @@
 - [CI greetings Bot](https://github.com/Ansub/SyntaxUI/pull/182) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
 - [Issue Template](https://github.com/Ansub/SyntaxUI/pull/72) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
 - [Automated Issue labeling](https://github.com/Ansub/SyntaxUI/pull/78) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
-- [Icon Toggle](https://syntaxui.com/components/toggle/icon-toggle) - [Shashank Verma](https://x.com/Shashank_V99)

--- a/credits.md
+++ b/credits.md
@@ -6,7 +6,6 @@
 - [LineTabs](https://syntaxui.com/components/tabs) - [Aiko](https://twitter.com/username_aiko)
 - [IconTabs](https://syntaxui.com/components/tabs) - [Aiko](https://twitter.com/username_aiko)
 - [Simple Toggle](https://syntaxui.com/components/toggle/simple-toggle) - [Ethan Pollack](https://epoll31.github.io)
-- [Icon Toggle](https://syntaxui.com/components/toggle/icon-toggle) - [Shashank Verma](https://x.com/Shashank_V99)
 - [Stitches Button](https://syntaxui.com/components/button/stitches-button) - [Saud](https://twitter.com/via_saud)
 - [Neubrutalism Toggle](https://syntaxui.com/components/button/neubrutalism-button) - [Ethan Pollack](https://epoll31.github.io)
 - [Shimmer Button](https://syntaxui.com/components/button/shimmer-button) - [Ethan Pollack](https://epoll31.github.io)
@@ -18,3 +17,4 @@
 - [CI greetings Bot](https://github.com/Ansub/SyntaxUI/pull/182) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
 - [Issue Template](https://github.com/Ansub/SyntaxUI/pull/72) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
 - [Automated Issue labeling](https://github.com/Ansub/SyntaxUI/pull/78) - [Daksh Singh Rathore](https://twitter.com/dakshsinghrath9)
+- [Icon Toggle](https://syntaxui.com/components/toggle/icon-toggle) - [Shashank Verma](https://x.com/Shashank_V99)

--- a/credits.md
+++ b/credits.md
@@ -6,6 +6,7 @@
 - [LineTabs](https://syntaxui.com/components/tabs) - [Aiko](https://twitter.com/username_aiko)
 - [IconTabs](https://syntaxui.com/components/tabs) - [Aiko](https://twitter.com/username_aiko)
 - [Simple Toggle](https://syntaxui.com/components/toggle/simple-toggle) - [Ethan Pollack](https://epoll31.github.io)
+- [Icon Toggle](https://syntaxui.com/components/toggle/icon-toggle) - [Shashank Verma](https://x.com/Shashank_V99)
 - [Stitches Button](https://syntaxui.com/components/button/stitches-button) - [Saud](https://twitter.com/via_saud)
 - [Neubrutalism Toggle](https://syntaxui.com/components/button/neubrutalism-button) - [Ethan Pollack](https://epoll31.github.io)
 - [Shimmer Button](https://syntaxui.com/components/button/shimmer-button) - [Ethan Pollack](https://epoll31.github.io)

--- a/src/app/(docs)/components/toggle/icon-toggle/page.mdx
+++ b/src/app/(docs)/components/toggle/icon-toggle/page.mdx
@@ -5,4 +5,4 @@ export const metadata = {
 
 <BackButton href="/components/toggle" />
 
-<ComponentPreview path="components/toggle/IconToggle" usingFramer/>
+<ComponentPreview path="components/toggle/IconToggle" usingCn/>

--- a/src/showcase/components/toggle/IconToggle.tsx
+++ b/src/showcase/components/toggle/IconToggle.tsx
@@ -1,7 +1,7 @@
 'use client'
-import React, { useState } from 'react'
-import { AnimatePresence, motion } from 'framer-motion'
+import React, { useState, useEffect } from 'react'
 import { Check, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 const IconToggle = ({
   onToggle,
@@ -9,56 +9,49 @@ const IconToggle = ({
   onToggle?: (toggled: boolean) => void
 }) => {
   const [toggled, setToggled] = useState(true)
+  const [showIcon, setShowIcon] = useState(false)
 
   const handleToggle = () => {
     const newState = !toggled
     setToggled(newState)
+    setShowIcon(false)
     if (onToggle) {
       onToggle(newState)
     }
   }
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowIcon(true)
+    }, 200)
+
+    return () => clearTimeout(timer)
+  }, [toggled])
+
   return (
     <button
-      className={`flex h-[25px] w-[45px] cursor-pointer items-center rounded-full p-[3px] justify-start duration-200`}
+      className={`relative h-7 w-12 cursor-pointer rounded-full duration-200`}
       onClick={handleToggle}
       style={{
         backgroundColor: toggled ? '#fb3a5d' : '#24252d50',
-        justifyContent: toggled ? 'end' : 'start',
       }}
     >
-      <motion.div
-        className="flex aspect-square h-full items-center justify-center rounded-full bg-white shadow-lg"
-        layout
-        transition={{ duration: 0.2 }}
-        animate={{
-          scale: toggled ? 1 : 0.9,
-        }}
+      <span
+        className={cn(
+          `absolute left-0 top-0 flex items-center justify-center rounded-full bg-white shadow-lg transition-all duration-200`,
+          toggled ? 'translate-x-full transform' : 'translate-x-0 transform',
+          toggled ? 'h-5 w-5' : 'h-4 w-4',
+          toggled ? 'm-1' : 'm-1.5',
+        )}
       >
-        <AnimatePresence mode="wait">
-          {toggled ? (
-            <motion.div
-              key="check"
-              initial={{ opacity: 0, scale: 0.5 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.5 }}
-              transition={{ duration: 0.1 }}
-            >
-              <Check size={13} strokeWidth={3} className="text-red-500" />
-            </motion.div>
+        {showIcon && (
+          toggled ? (
+            <Check size={13} strokeWidth={3} className="text-red-500 transition-opacity duration-100" />
           ) : (
-            <motion.div
-              key="x"
-              initial={{ opacity: 0, scale: 0.5 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.5 }}
-              transition={{ duration: 0.1 }}
-            >
-              <X size={13} strokeWidth={3} className="text-[#24252d50]" />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </motion.div>
+            <X size={13} strokeWidth={3} className="text-[#24252d50] transition-opacity duration-100" />
+          )
+        )}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Description

Removed the Framer Motion dependency from the Icon Toggle Component .

## Related Issue

Fixes #201 

## Proposed Changes

- Modified `src/showcase/components/toggle/IconToggle.tsx`
  - Removed framer-motion references.
  - Achieved the same transition effect using Tailwind CSS directly, instead of combining it with Framer Motion.
  - Added a local version of the `cn` function for code preview visibility.
- Modified `src/app/(docs)/components/toggle/icon-toggle/page.mdx`
  - Removed `usingFramer` prop from Component Preview.
  - Added `usingCn` prop in Component Preview.

## Screenshots

![ScreenRecording2024-05-30at12 26 32AM-ezgif com-video-to-gif-converter](https://github.com/SyntaxUI/syntaxui/assets/8446697/00418f79-52c8-48ff-bd86-33982c9b61a3)


## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
