### PR TITLE
Fixed `Get Portfolio Template` button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,34 +11,27 @@ import { motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 
-const DiscordButton = () => {
-  const router = useRouter()
-
+const TemplatesButton = () => {
   return (
-    <motion.button
-      className="relative mb-8 inline-flex overflow-hidden rounded-full p-[1px] ring-1 ring-inset ring-blue-700/10"
-      initial={{ opacity: 0, scale: 0.5 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.5 }}
-      whileHover={{ scale: 1.1 }}
-      whileTap={{ scale: 0.9 }}
-      onClick={() => {
-        // window.open('https://cal.com/ansub/15')
-        // window.open('https://discord.com/invite/P8GXYyH3ZU')
-        router.push('/templates/minimal-portfolio')
-        // posthog.capture('meeting_button_clicked')
-      }}
-    >
-      <span className="absolute inset-[-1000%] animate-discord-button bg-[conic-gradient(from_calc(var(--discord-button-angle)+60deg)_at_calc(50%+var(--discord-button-x))_50%,transparent_50%,#fb3a5d_98%,transparent_100%)]"></span>
-      <span className="inline-flex items-center gap-2 rounded-full bg-red-100 px-3 py-1 text-[12px] font-medium uppercase text-red-500 backdrop-blur">
-        <span>
-          Get Portfolio Template
-          <ChevronRight className="inline-block h-4 w-4 text-red-400" />
+    <Link href="/templates" passHref>
+      <motion.a
+        className="relative mb-8 inline-flex overflow-hidden rounded-full p-[1px] ring-1 ring-inset ring-blue-700/10"
+        initial={{ opacity: 0, scale: 0.5 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.5 }}
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.9 }}
+      >
+        <span className="absolute inset-[-1000%] animate-discord-button bg-[conic-gradient(from_calc(var(--discord-button-angle)+60deg)_at_calc(50%+var(--discord-button-x))_50%,transparent_50%,#fb3a5d_98%,transparent_100%)]"></span>
+        <span className="inline-flex items-center gap-2 rounded-full bg-red-100 px-3 py-1 text-[12px] font-medium uppercase text-red-500 backdrop-blur">
+          <span>
+            Get Portfolio Template
+            <ChevronRight className="inline-block h-4 w-4 text-red-400" />
+          </span>
         </span>
-      </span>
-    </motion.button>
+      </motion.a>
+    </Link>
   )
 }
 
@@ -49,7 +42,7 @@ const Home = () => {
         <Header />
         <div className="my-[8rem] flex h-full flex-col items-center justify-center gap-4 px-3">
           <div className="flex w-full flex-col items-center justify-center gap-2">
-            <DiscordButton />
+            <TemplatesButton />
             <Image
               src="/images/syntaxUI.svg"
               alt="syntaxUI"


### PR DESCRIPTION
## Description

I fixed the homepage button that says 'Get Portfolio Template'

## Proposed Changes

- Renamed `DiscordButton` to `TemplatesButton`
- Removed the `useRouter` navigation onClick in favor of a normal `Link` with a `passHref` to a `motion.a`
- Changed the href to `/templates` because the original pr removed the `/templates/minimal-portfolio` path

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
