### PR TITLE
fixes the active state of the naviagtion component

### DIFF
--- a/src/app/(docs)/animations/skewed-infinite-scroll/page.mdx
+++ b/src/app/(docs)/animations/skewed-infinite-scroll/page.mdx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/table'
 
 export const metadata = {
-  title: 'Skewed Infinite Scroll',
+  title: ' Infinite Scroll',
   description: 'A skewed infinite scroll animation',
 }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -38,14 +38,18 @@ function NavLink({
   active?: boolean
   isAnchorLink?: boolean
 }) {
+  const isActive = usePathname().startsWith(href); //checking if the pathname starts with the link's href.
+
   return (
     <Link
       href={href}
-      aria-current={active ? 'page' : undefined}
+      // aria-current={active ? 'page' : undefined}
+      aria-current={isActive ? 'page' : undefined}
+
       className={clsx(
         'flex justify-between gap-2 py-1 pr-3 text-sm transition',
         isAnchorLink ? 'pl-7' : 'pl-4',
-        active
+        isActive
           ? 'text-gray-900 dark:text-white'
           : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white',
       )}
@@ -108,7 +112,8 @@ function ActivePageMarker({
 }) {
   let itemHeight = remToPx(2)
   let offset = remToPx(0.25)
-  let activePageIndex = group.links.findIndex((link) => link.href === pathname)
+  // let activePageIndex = group.links.findIndex((link) => link.href === pathname)
+  let activePageIndex = group.links.findIndex((link) => pathname.startsWith(link.href))   //  // Find the index of the link whose href is the prefix of the pathname
   let top = offset + activePageIndex * itemHeight
 
   return (


### PR DESCRIPTION
## Description

This pull request addresses an issue where the "Button" component in the sidebar does not show as active when navigating to sub-routes like /components/button/neubrutalism-button. The changes ensure that the sidebar correctly highlights the "Button" component link when on any of its sub-routes.

## Related Issue

https://github.com/SyntaxUI/syntaxui/issues/173

Fixes # (issue)

## Proposed Changes

-> Modify the NavLink component to check if the pathname starts with the link's href to determine the active state.
-> Adjust the ActivePageMarker component to handle the same logic, ensuring correct highlighting in the sidebar.
- ...

## Screenshots

![Screenshot from 2024-06-15 01-14-09](https://github.com/SyntaxUI/syntaxui/assets/120778312/bf2d9f1c-9f9c-4c91-882d-80af6fe7b5f8)

![Screenshot from 2024-06-15 01-16-54](https://github.com/SyntaxUI/syntaxui/assets/120778312/b40656ae-06fb-4bac-9201-23a7243678b6)




## Checklist

Please check the boxes that apply:

- [✅ ] I have rebased my branch on top of the latest `main` branch.
- [✅ ] I have tested the changes locally
- [✅ ] I ran `npm run build` and build is successful
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the credits.md file (if applicable)


