### PR TITLE
fix: added active state for sub-pages

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -25,6 +25,13 @@ function useInitialValue<T>(value: T, condition = true) {
   return condition ? initialValue : value
 }
 
+function matchPath(pathname: string, href: string) {
+  if (href === '/components') {
+    return pathname === '/components'
+  }
+  return pathname.startsWith(href)
+}
+
 function NavLink({
   href,
   children,
@@ -83,7 +90,8 @@ function VisibleSectionHighlight({
     ? Math.max(1, visibleSections.length) * itemHeight
     : itemHeight
   let top =
-    group.links.findIndex((link) => link.href === pathname) * itemHeight +
+    group.links.findIndex((link) => matchPath(pathname, link.href)) *
+      itemHeight +
     firstVisibleSectionIndex * itemHeight
 
   return (
@@ -108,7 +116,9 @@ function ActivePageMarker({
 }) {
   let itemHeight = remToPx(2)
   let offset = remToPx(0.25)
-  let activePageIndex = group.links.findIndex((link) => link.href === pathname)
+  let activePageIndex = group.links.findIndex((link) =>
+    matchPath(pathname, link.href),
+  )
   let top = offset + activePageIndex * itemHeight
 
   return (
@@ -143,7 +153,7 @@ function NavigationGroup({
   )
 
   let isActiveGroup =
-    group.links.findIndex((link) => link.href === pathname) !== -1
+    group.links.findIndex((link) => matchPath(pathname, link.href)) !== -1
 
   return (
     <li className={clsx('relative mt-6', className)}>
@@ -173,13 +183,13 @@ function NavigationGroup({
             <motion.li key={link.href} layout="position" className="relative">
               <NavLink
                 href={link.href}
-                active={link.href === pathname}
+                active={matchPath(pathname, link.href)}
                 tag={link.tag}
               >
                 {link.title}
               </NavLink>
               <AnimatePresence mode="popLayout" initial={false}>
-                {link.href === pathname && sections.length > 0 && (
+                {matchPath(pathname, link.href) && sections.length > 0 && (
                   <motion.ul
                     role="list"
                     initial={{ opacity: 0 }}


### PR DESCRIPTION
## Description

added active state for sub-pages

## Related Issue

Fixes #173 

## Proposed Changes

- added a new `matchPath` helper function to `src/components/Navigation.tsx`
- using `matchPath` instead of `link.href === pathname` throughout file

## Screenshots

<img width="431" alt="Screenshot 2024-06-20 at 10 25 24 AM" src="https://github.com/SyntaxUI/syntaxui/assets/16091805/b3e7a46a-08f8-4000-8ff3-9da0e1d9f9ed">

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)

## Additional Context

Please provide any additional context or information about the pull request here.
