### PR TITLE
Fix issue 239: Incorrect pricing displayed for the stoic template

### DIFF
--- a/src/app/templates/[id]/page.tsx
+++ b/src/app/templates/[id]/page.tsx
@@ -74,8 +74,8 @@ const Template = () => {
               )}
             </div>
             <div className="flex flex-row items-center gap-1 text-lg">
-              <p className="font-semibold text-red-500">$19</p>
-              <p className="text-xs text-gray-600/50 line-through">$39</p>
+              <p className="font-semibold text-red-500">${template?.price}</p>
+              <p className="text-xs text-gray-600/50 line-through">${template?.originalPrice}</p>
             </div>
             <div className="mt-2 max-w-sm text-left text-sm text-gray-600 dark:text-gray-200">
               {template.description}


### PR DESCRIPTION
### Issue:
Incorrect pricing displayed for the Stoic template. The template listing was static.

### Fix:
Updated the template listing to be dynamic, pulling pricing data directly from the `template` object. This ensures that the displayed prices are always current.

### Changes:
- Changed static pricing display to dynamic fields sourced from `template.price` and `template.originalPrice`.

