### PR TITLE
fix the border color changing issue when navigating from code to preview in dark mode.

### DIFF
--- a/src/components/code/Code.tsx
+++ b/src/components/code/Code.tsx
@@ -52,7 +52,7 @@ export default function Code({
   return (
     <div
       className={cn(
-        'overflow-x-auto border border-gray-600 bg-zinc-900 pb-0 dark:border-gray-600',
+        'overflow-x-auto border border-gray-700 bg-zinc-900 pb-0 dark:border-gray-700',
         rounded ? 'rounded-b-lg rounded-t-none' : 'rounded-lg',
         inCodeGroup && 'border-0',
       )}


### PR DESCRIPTION


## Description

changes the border color that causing the issue in in dark mode in ComponentPreview component from navigating from code to preview.It was coded border-gray-600 in dark mode and for light mode in code component that causing inconsistency in color.

## Related Issue

https://github.com/SyntaxUI/syntaxui/issues/243

Fixes # (issue)

## Proposed Changes

- Change -> change the border color from bg-gray-600 to bg-gray-700 



## Screenshots

[Screencast from 2024-06-25 21-25-10.webm](https://github.com/SyntaxUI/syntaxui/assets/120778312/f7ecdd5b-195c-4536-b3db-6e3b3b9983a9)


## Checklist

Please check the boxes that apply:

- [✅ ] I have rebased my branch on top of the latest `main` branch.
- [ ✅] I have tested the changes locally
- [✅ ] I ran `npm run build` and build is successful
- [ ] I have added necessary documentation (if applicable)
- [ ] I have updated the credits.md file (if applicable)


