### PR TITLE
Feat:  Duplicate Tags in TagInput Component

### DIFF
--- a/src/app/(docs)/components/input/page.mdx
+++ b/src/app/(docs)/components/input/page.mdx
@@ -16,14 +16,18 @@ Some Key Features of Tag Input are:
 - Add keywords by pressing Enter or comma
 - Remove keywords by clicking the remove button (X icon) or pressing Backspace
 - Paste multiple keywords separated by commas, new lines, or tabs
+- Prevents duplicate keywords by using the unique prop
 
 <div className="mb-4"></div>
 <Preview>
-<div className="max-w-md w-full my-12">
-<TagInput/>
+<div className="max-w-md w-full my-12 flex flex-col gap-4">
+  <div className="text-lg font-semibold">Duplicate Keywords</div>
+  <TagInput />
+  <div className="text-lg font-semibold">Unique Keywords</div>  
+  <TagInput unique />
 </div>
 </Preview>
- <CodeGroup title="TagInput.tsx">
+<CodeGroup title="TagInput.tsx">
 
     ```jsx {{ title: 'React' }}
 
@@ -33,11 +37,13 @@ import { X } from 'lucide-react'
 interface KeywordsInputProps {
 initialKeywords?: string[]
 onKeywordsChange: (keywords: string[]) => void
+unique: boolean
 }
 
 const KeywordsInput: React.FC<KeywordsInputProps> = ({
 initialKeywords = [],
 onKeywordsChange,
+unique = false,
 }) => {
 const [keywords, setKeywords] = useState<string[]>(initialKeywords)
 const [inputValue, setInputValue] = useState<string>('')
@@ -49,7 +55,9 @@ if (
 event.key === ',') && inputValue.trim() !== ''
 ) {
 event.preventDefault()
-const newKeywords = [...keywords, inputValue.trim()]
+const newKeywords = unique
+? [...new Set([...keywords, newKeyword])]
+: [...keywords, newKeyword]
 setKeywords(newKeywords)
 onKeywordsChange(newKeywords)
 setInputValue('')
@@ -70,7 +78,9 @@ const keywordsToAdd = paste
 .map((keyword) => keyword.trim())
 .filter(Boolean)
 if (keywordsToAdd.length) {
-const newKeywords = [...keywords, ...keywordsToAdd]
+const newKeywords = unique
+? [...new Set([...keywords, ...keywordsToAdd])]
+: [...keywords, ...keywordsToAdd]
 setKeywords(newKeywords)
 onKeywordsChange(newKeywords)
 setInputValue('')
@@ -93,7 +103,7 @@ setInputValue('')
 
 // Removes a keyword from the list
 const removeKeyword = (indexToRemove: number) => {
-const newKeywords = keywords.filter((_, index) => index !== indexToRemove)
+const newKeywords = keywords.filter((\_, index) => index !== indexToRemove)
 setKeywords(newKeywords)
 onKeywordsChange(newKeywords)
 }
@@ -154,6 +164,7 @@ return (
   <KeywordsInput
     initialKeywords={keywords}
     onKeywordsChange={handleKeywordsChange}
+    unique
   />
 </>
 ); };

--- a/src/app/(docs)/components/input/page.mdx
+++ b/src/app/(docs)/components/input/page.mdx
@@ -20,10 +20,7 @@ Some Key Features of Tag Input are:
 
 <div className="mb-4"></div>
 <Preview>
-<div className="max-w-md w-full my-12 flex flex-col gap-4">
-  <div className="text-lg font-semibold">Duplicate Keywords</div>
-  <TagInput />
-  <div className="text-lg font-semibold">Unique Keywords</div>  
+<div className="max-w-md w-full my-12">
   <TagInput unique />
 </div>
 </Preview>

--- a/src/showcase/components/input/TagInput.tsx
+++ b/src/showcase/components/input/TagInput.tsx
@@ -3,7 +3,11 @@
 import React, { useState } from 'react'
 import { X } from 'lucide-react'
 
-const TagInput: React.FC = () => {
+interface TagInputProps {
+  unique: boolean
+}
+
+const TagInput: React.FC<TagInputProps> = ({ unique = false }) => {
   const [keywords, setKeywords] = useState<string[]>(['ansub', 'syntax'])
 
   const onKeywordsChange = (newKeywords: string[]) => {
@@ -19,7 +23,12 @@ const TagInput: React.FC = () => {
       inputValue.trim() !== ''
     ) {
       event.preventDefault()
-      const newKeywords = [...keywords, inputValue.trim()]
+      const newKeyword = inputValue.trim()
+
+      const newKeywords = unique
+        ? [...new Set([...keywords, newKeyword])]
+        : [...keywords, newKeyword]
+
       setKeywords(newKeywords)
       onKeywordsChange(newKeywords)
       setInputValue('')
@@ -40,7 +49,11 @@ const TagInput: React.FC = () => {
       .map((keyword) => keyword.trim())
       .filter(Boolean)
     if (keywordsToAdd.length) {
-      const newKeywords = [...keywords, ...keywordsToAdd]
+      // const newKeywords = [...keywords, ...keywordsToAdd]
+      const newKeywords = unique
+        ? [...new Set([...keywords, ...keywordsToAdd])]
+        : [...keywords, ...keywordsToAdd]
+
       setKeywords(newKeywords)
       onKeywordsChange(newKeywords)
       setInputValue('')

--- a/src/showcase/components/input/TagInput.tsx
+++ b/src/showcase/components/input/TagInput.tsx
@@ -24,7 +24,6 @@ const TagInput: React.FC<TagInputProps> = ({ unique = false }) => {
     ) {
       event.preventDefault()
       const newKeyword = inputValue.trim()
-
       const newKeywords = unique
         ? [...new Set([...keywords, newKeyword])]
         : [...keywords, newKeyword]
@@ -49,7 +48,6 @@ const TagInput: React.FC<TagInputProps> = ({ unique = false }) => {
       .map((keyword) => keyword.trim())
       .filter(Boolean)
     if (keywordsToAdd.length) {
-      // const newKeywords = [...keywords, ...keywordsToAdd]
       const newKeywords = unique
         ? [...new Set([...keywords, ...keywordsToAdd])]
         : [...keywords, ...keywordsToAdd]


### PR DESCRIPTION
## Description
This pull request addresses the issue of duplicate tags being added in the TagInput component. A unique prop has been introduced to control whether duplicate tags should be allowed.

## Related Issues
Fix #247 

## Changes

1. **Component Enhancement**:
   - Added a new prop `unique` to the `TagInput` component.
   - Updated the keyword handling logic to prevent duplicates when `unique` is set to `true`.

2. **Keyword Addition**:
   - When the `Enter` key or comma is pressed, the component adds the new keyword if it's not already present in the list.
   - Paste handling ensures that only unique keywords are added to the list when `unique` is set to `true`.

## Key Features
- **Unique Keywords**: When the `unique` prop is enabled, duplicate keywords are prevented.

## Example Usage
```jsx
<TagInput unique />
```

## Screenshots

Before:

![image](https://github.com/SyntaxUI/syntaxui/assets/92374720/e5e67830-dce1-4629-a505-97f0c75a4522)


After:

![image](https://github.com/SyntaxUI/syntaxui/assets/92374720/22ee97a6-aa79-4f43-9288-919e563bc59f)

