### PR TITLE
fix: Banner Not Hiding Properly

### DIFF
--- a/src/components/code/ComponentPreview.tsx
+++ b/src/components/code/ComponentPreview.tsx
@@ -169,7 +169,7 @@ export function ComponentPreview({
         />
       </div>
       {selectedTab === 'preview' && (
-        <div className="relative rounded-md border border-gray-200 dark:border-gray-700 ">
+        <div className="relative overflow-hidden rounded-md border border-gray-200 dark:border-gray-700">
           <CopyButton value={codeString} />
           <div>
             <div


### PR DESCRIPTION
## Description

added appropriate overflow-hidden

## Related Issue

Fixes #250 

## Proposed Changes

- Added `overflow-hidden` to nearest ancestor element that contains `relative` since the `Banner` uses `absolute`.

## Checklist

Please check the boxes that apply:

- [x] I have rebased my branch on top of the latest `main` branch.
- [x] I have tested the changes locally
- [x] I ran `npm run build` and build is successful
- [x] I have added necessary documentation (if applicable)
- [x] I have updated the credits.md file (if applicable)
